### PR TITLE
add check for "UnidentifiedImageError"

### DIFF
--- a/brails/modules/GenericImageClassifier/GenericImageClassifier.py
+++ b/brails/modules/GenericImageClassifier/GenericImageClassifier.py
@@ -15,6 +15,7 @@ import types
 import random
 import pathlib
 import argparse
+import warnings
 from glob import glob
 
 import tensorflow as tf
@@ -24,6 +25,7 @@ from tensorflow.keras.preprocessing import image
 from tensorflow.keras.models import load_model
 from tensorflow.keras.preprocessing import image_dataset_from_directory
 from tensorflow.keras.applications.inception_v3 import preprocess_input
+from PIL import UnidentifiedImageError
 from brails.modules.ModelZoo import zoo
 import matplotlib.pyplot as plt
 
@@ -109,7 +111,13 @@ class ImageClassifier:
                 if self.classNames: prediction = self.classNames[prediction]
                 predictions.append(prediction)
             '''
-            img = image.load_img(imagePath, color_mode=color_mode, target_size=(256, 256))
+            try:
+                img = image.load_img(imagePath, color_mode=color_mode, target_size=(256, 256))
+            except UnidentifiedImageError:
+                warnings.warn(f"Image format error: skipping image '{imagePath}'")
+                probs.append(None)
+                predictions.append(None)
+                continue
             x = image.img_to_array(img)
             x = np.expand_dims(x, axis=0)
             prediction = self.model.predict(x)

--- a/brails/workflow/Images.py
+++ b/brails/workflow/Images.py
@@ -15,6 +15,26 @@ from multiprocessing.dummy import Pool as ThreadPool
 import requests 
 from pathlib import Path
 
+try:
+    # Requires Python 3.9
+    from functools import cache
+except ImportError:
+    cache = lambda x: x
+
+@cache
+def validateGoogleMapsAPI(key: str)->bool:
+    """Validate a Google Maps API key.
+    
+    The `@cache` decorator automatically creates a
+    cache for API values so that a validation process
+    will only be run the first time the function is 
+    called.
+
+    `bool(key)` will be false for both the empty
+    string, `''`, and `None` values. This function
+    should be expanded.
+    """
+    return bool(key) and key != 'put-your-key-here'
 
 def capturePic(browser, picname):
     try:
@@ -86,12 +106,10 @@ def download(urls):
 def getGoogleImages(footprints=None, GoogleMapAPIKey='',imageTypes=['StreetView','TopView'],imgDir='',ncpu=2,fov=60,pitch=0,reDownloadImgs=False):
 
     if footprints is None:
-        print('Please provide footprints') 
-        return None
+        raise ValueError('Please provide footprints') 
 
-    if GoogleMapAPIKey == '':
-        print('Please provide GoogleMapAPIKey') 
-        return None
+    if not validateGoogleMapsAPI(GoogleMapAPIKey):
+        raise ValueError('Invalid GoogleMapAPIKey.') 
 
     for imgType in imageTypes:
         tmpImgeDir = os.path.join(imgDir, imgType)
@@ -140,12 +158,10 @@ def getGoogleImages(footprints=None, GoogleMapAPIKey='',imageTypes=['StreetView'
 def getGoogleImagesByAddrOrCoord(Addrs=None, GoogleMapAPIKey='',imageTypes=['StreetView','TopView'],imgDir='',ncpu=2,fov=60,pitch=0,reDownloadImgs=False):
 
     if Addrs is None:
-        print('Please provide Addrs') 
-        return None
+        raise ValueError('Please provide Addrs') 
 
-    if GoogleMapAPIKey == '':
-        print('Please provide GoogleMapAPIKey') 
-        return None
+    if not validateGoogleMapsAPI(GoogleMapAPIKey):
+        raise ValueError('Invalid GoogleMapAPIKey.') 
 
     for imgType in imageTypes:
         tmpImgeDir = os.path.join(imgDir, imgType)

--- a/brails/workflow/Images.py
+++ b/brails/workflow/Images.py
@@ -14,18 +14,13 @@ import random
 from multiprocessing.dummy import Pool as ThreadPool
 import requests 
 from pathlib import Path
+from functools import lru_cache
 
-try:
-    # Requires Python 3.9
-    from functools import cache
-except ImportError:
-    cache = lambda x: x
-
-@cache
+@lru_cache(maxsize=None)
 def validateGoogleMapsAPI(key: str)->bool:
     """Validate a Google Maps API key.
     
-    The `@cache` decorator automatically creates a
+    The `@lru_cache` decorator automatically creates a
     cache for API values so that a validation process
     will only be run the first time the function is 
     called.


### PR DESCRIPTION
This patch modifies the `GenericImageClassifier::predictMulti` method to skip over images which are invalid and raise a warning.

a new skeleton function is also added for validation of API keys; see notes below.
